### PR TITLE
Add link checking using GitHub Actions

### DIFF
--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -1,7 +1,12 @@
 name: Link Check
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   check-links:

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -1,0 +1,20 @@
+name: Link Check
+
+on:
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.5.0
+        with:
+          args: --config ./lychee.toml
+          format: markdown
+          jobSummary: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -13,7 +13,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.5.0
         with:
-          args: --config ./lychee.toml
+          args: --config ./lychee.toml --no-progress --verbose ./docs
           format: markdown
           jobSummary: true
         env:

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -16,5 +16,6 @@ jobs:
           args: --config ./lychee.toml --no-progress --verbose ./docs
           format: markdown
           jobSummary: true
+          fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -9,3 +9,20 @@ https://nmdc-workflow-documentation.readthedocs.io/en/latest/chapters/overview.h
 
 NMDC Data Portal User Guide ReadtheDocs
 https://the-nmdc-portal-user-guide.readthedocs.io/en/latest/
+
+## Link Checking
+
+Checking for dead links will happen automatically as a GitHub Action on pull requests
+or commits to `main`. Link checking is done using [lychee](https://github.com/lycheeverse/lychee).
+
+If you have installed lychee locally, you can run:
+
+```shell
+lychee ./docs --format markdown --output ./lychee.md
+```
+
+Alternatively you can run via Docker:
+
+```shell
+docker run --init --rm -it -v `pwd`:/input -w "/input" lycheeverse/lychee /input/docs --format markdown --output /input/lychee.md
+```

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,6 @@
+max_retries = 3
+max_concurrency = 64
+exclude_mail = true
+insecure = true
+exclude = ['https://microbiomedata']
+headers = ['Accept=text/html,*/*']


### PR DESCRIPTION
These changes use [lychee](https://github.com/lycheeverse/lychee) to check docs for dead links. Automated checking will happen on pull requests and pushes to `main`. Instructions have been added to the README about how to run the process locally before committing as well. 

The `lychee.toml` configuration file excludes links to `https://microbiomedata/`. That should be addressed at the schema level, but in the meantime those links generate too much noise in the report. There is an issue for it here: https://github.com/microbiomedata/nmdc-schema/issues/362

Fixes #9 