### PR TITLE
Redirect old schema docs pages to `github.io` site

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,8 @@ release = '0.1'
 # ones.
 extensions = [
    'myst_parser',
-   'sphinx_markdown_tables'
+   'sphinx_markdown_tables',
+   'sphinx_reredirects'
 ]
 
 # source_suffix = '.rst'
@@ -66,3 +67,13 @@ html_css_files = [
     'css/custom.css',
 ]
 html_logo = "_static/images/nmdc-logo-bg-white.png"
+
+# -- Redirects ------------------------------------------
+
+# Redirect old schema documentation URLs to the schema documentation
+# that is automatically kept in sync with the schema.
+# Reference: https://pypi.org/project/sphinx-reredirects/
+redirects = {
+    "reference/metadata/xylene": "https://w3id.org/nmdc/xylene",  # the latter redirects to: https://microbiomedata.github.io/nmdc-schema/xylene/
+    "reference/metadata/*": "https://w3id.org/nmdc/nmdc",
+}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,7 @@
 myst-parser
 sphinx_markdown_tables
 sphinx_rtd_theme
+
+# Sphinx plugin that handles redirects.
+# Reference: https://pypi.org/project/sphinx-reredirects/
+sphinx-reredirects


### PR DESCRIPTION
In this branch, I put into place a set of redirects that make it so that, when someone visits the URL of a schema documentation page, they are automatically redirected to some page on https://microbiomedata.github.io/nmdc-schema (using a `w3id.org` URL).

This branch was created during the July 12, 2024, hackathon. Hackaton breakout room attendees include: @eecavanna , @aclum , @mslarae13 , @turbomam 