### PR TITLE
Capture source path segment and append to destination path

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,10 +70,17 @@ html_logo = "_static/images/nmdc-logo-bg-white.png"
 
 # -- Redirects ------------------------------------------
 
-# Redirect old schema documentation URLs to the schema documentation
-# that is automatically kept in sync with the schema.
-# Reference: https://pypi.org/project/sphinx-reredirects/
+# Redirect URLs that originally led to local, manually-maintained schema documentation web pages,
+# so that they instead lead to remote, automatically-maintained schema documentation web pages.
+#
+# Reference: https://documatt.com/sphinx-reredirects/usage.html#target-placeholders
+#
 redirects = {
-    "reference/metadata/xylene": "https://w3id.org/nmdc/xylene",  # the latter redirects to: https://microbiomedata.github.io/nmdc-schema/xylene/
-    "reference/metadata/*": "https://w3id.org/nmdc/nmdc",
+    # Note: The portion of the source path matched by the `*` is available in the target path as `${source}`.
+    #
+    # Example: The code below redirects https://nmdc-documentation.readthedocs.io/en/latest/reference/metadata/xylene.html
+    #          to https://w3id.org/nmdc/xylene. Then, the code in https://github.com/perma-id/w3id.org/blob/master/nmdc/.htaccess
+    #          (not in this repo) redirects https://w3id.org/nmdc/xylene to https://microbiomedata.github.io/nmdc-schema/xylene/.
+    #
+    "reference/metadata/*": "https://w3id.org/nmdc/${source}",
 }


### PR DESCRIPTION
In this branch, I deleted the two original redirects that existed and replaced them with a new one. The new one is designed to capture the portion of the original URL following `/reference/metadata` and append it to `https://w3id.org/nmdc/`, and then redirect the user to the resulting URL.

For example: If a user visits https://nmdc-documentation.readthedocs.io/en/latest/reference/metadata/xylene.html, I designed the redirect to redirect them to https://w3id.org/nmdc/xylene (which—outside of this repo—will redirect them to https://microbiomedata.github.io/nmdc-schema/xylene/.

I am not sure this redirection plugin supports having a combination of wildcard and non-wildcard sources, which is what the two original redirects—together—were. It may be the case that the wildcard overrode any other sources. This is not addressed in the plugin's documentation.