### PR TITLE
Update links for data portal documentation

### DIFF
--- a/docs/reference/data_portal.md
+++ b/docs/reference/data_portal.md
@@ -7,13 +7,15 @@ The main technologies upon which it is built are:
 * [Python](https://www.python.org/) and [FastAPI](https://fastapi.tiangolo.com/)
 * [PostgreSQL](https://www.postgresql.org/) and [SQLAlchemy](https://www.sqlalchemy.org/)
 * [Celery](https://docs.celeryq.dev/) and [Redis](https://redis.io/)
-* [Vue.js](https://vuejs.org/) and [Vuetify](https://vuetifyjs.com/)
+* [Vue.js](https://v2.vuejs.org/) and [Vuetify](https://v2.vuetifyjs.com/)
+
+For specific versions  of these technologies currently being used by the NMDC Data Portal, see the Dependencies below.
 
 ### Dependencies
 
 The NMDC Data Portal depends upon various Python and JavaScript libraries, which are listed in either of the following documents:
 
-* [Python dependencies](https://github.com/microbiomedata/nmdc-server/blob/main/setup.py)
+* [Python dependencies](https://github.com/microbiomedata/nmdc-server/blob/main/pyproject.toml)
 * [Javascript dependencies](https://github.com/microbiomedata/nmdc-server/blob/main/web/package.json)
 
 ## Architecture
@@ -30,5 +32,5 @@ Information about the HTTP API is in this [wiki](https://github.com/microbiomeda
 
 Here are some resources people can use to learn about the development of the NMDC Data Portal.
 
-* [Server and client development documentation](https://github.com/microbiomedata/nmdc-server)
+* [Server and client development documentation](https://github.com/microbiomedata/nmdc-server/blob/main/docs/development.md)
 * [Client architecture notes](https://github.com/microbiomedata/nmdc-server/blob/main/web/README.md)


### PR DESCRIPTION
See microbiomedata/docs/issues/29

### Changes

Some links in the updated document were out of date or possible confusing.

1. Vue and Vuetify links point to the version of those tools that the NMDC Data Portal is *currently* using, rather than the most recent versions.
2. The link to `settings.py` has been updated to point to `pyproject.toml`, which replaced the former.
3. The link to "Server and client development documentation" points to the specific markdown file with the information in the `nmdc-server` [repo](https://github.com/microbiomedata/nmdc-server), rather than the front page of the repo.